### PR TITLE
Increasing tenant backoff timeout to give time for openshift-ai-operator to create all CRDs

### DIFF
--- a/components/argocd/apps/base/tenants-applicationset.yaml
+++ b/components/argocd/apps/base/tenants-applicationset.yaml
@@ -31,7 +31,7 @@ spec:
         retry:
           limit: 5
           backoff:
-            duration: 5s
+            duration: 30s
             factor: 2
             maxDuration: 20m
       source:


### PR DESCRIPTION
…or to create all CRDs